### PR TITLE
Updated hook.lua - move autorefresh check

### DIFF
--- a/lua/ulib/shared/hook.lua
+++ b/lua/ulib/shared/hook.lua
@@ -1,3 +1,4 @@
+if hook.GetULibTable then return end	-- Prevent autorefresh reloading this file
 
 local gmod			= gmod
 local pairs			= pairs
@@ -20,8 +21,6 @@ HOOK_HIGH = -1
 HOOK_NORMAL = 0
 HOOK_LOW = 1
 HOOK_MONITOR_LOW = 2
-
-if hook.GetULibTable then return end	-- Prevent autorefresh reloading this file
 
 -- Grab all previous hooks from the pre-existing hook module.
 local OldHooks = hook.GetTable()


### PR DESCRIPTION
Updated hook.lua - move autorefresh check to save some nanoseconds of CPU and some bytes of RAM.
