### PR TITLE
Migrate UCL user store from flat file to SQLite.

### DIFF
--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -145,7 +145,7 @@ function ucl.saveUser( steamid, userInfo )
 
 	table.sort( userInfo.allow )
 	table.sort( userInfo.deny )
-	local allow, deny = ULib.makeKeyValues( userInfo.allow ), ULib.makeKeyValues( userInfo.deny )
+	local allow, deny = util.TableToJSON( userInfo.allow ), util.TableToJSON( userInfo.deny )
 
 	sql.Query(string.format([[
 		REPLACE INTO ulib_users
@@ -275,7 +275,7 @@ local function loadUsersFromDB()
 
 	local out = {}
 	for _, row in ipairs(users) do
-		out[row.steamid] = {name = row.name, group = row.usergroup, allow = ULib.parseKeyValues(row.allow) or {}, deny = ULib.parseKeyValues(row.deny) or {}}
+		out[row.steamid] = {name = row.name, group = row.usergroup, allow = util.JSONToTable(row.allow) or {}, deny = util.JSONToTable(row.deny) or {}}
 	end
 
 	return out

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -300,7 +300,7 @@ local function reloadUsers()
 
 	local needsBackup = false
 	local err
-	ucl.users, err = ULib.parseKeyValues( ULib.removeCommentHeader( ULib.fileRead( path, true ) or "", "/" ) )
+	ucl.users, err = ULib.parseKeyValues( ULib.removeCommentHeader( ULib.fileRead( path, noMount ) or "", "/" ) )
 
 	-- Check to make sure it passes a basic validity test
 	if not ucl.users then

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -136,17 +136,21 @@ local function escape(str)
 	return sql.SQLStr(str, true)
 end
 
-function ucl.saveUser(steamid, userInfo)
-	table.sort(userInfo.allow)
-	table.sort(userInfo.deny)
-	local allow, deny = ULib.makeKeyValues(userInfo.allow), ULib.makeKeyValues(userInfo.deny)
+function ucl.saveUser( steamid, userInfo )
+	if not userInfo then
+		userInfo = ucl.users[ steamid ]
+	end
+
+	table.sort( userInfo.allow )
+	table.sort( userInfo.deny )
+	local allow, deny = ULib.makeKeyValues( userInfo.allow ), ULib.makeKeyValues( userInfo.deny )
 
 	sql.Query(string.format([[
 		REPLACE INTO ulib_users
 			(steamid, name, usergroup, allow, deny)
 		VALUES
 			('%s', '%s', '%s', '%s', '%s');
-	]], escape(steamid), escape(userInfo.name), escape(userInfo.group), escape(allow), escape(deny)))
+	]], escape( steamid ), escape( userInfo.name or "" ), escape( userInfo.group ), escape( allow ), escape( deny )))
 end
 
 local function reloadGroups()

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -117,6 +117,7 @@ function ucl.saveUsers()
 	ULib.fileWrite( ULib.UCL_USERS, ULib.makeKeyValues( ucl.users ) )
 end
 
+local isFirstTimeDBSetup = false
 function ucl.generateUserDB()
 	if not sql.TableExists("ulib_users") then
 		sql.Query([[
@@ -128,6 +129,7 @@ function ucl.generateUserDB()
 				deny TEXT
 			);
 		]])
+		isFirstTimeDBSetup = true
 	end
 end
 ucl.generateUserDB()
@@ -281,11 +283,14 @@ end
 
 local function reloadUsers()
 	-- Start by trying to read from the DB.
-	ucl.users = loadUsersFromDB()
-	if ucl.users then
-		-- We've loaded the users, so we don't need to do anything with the legacy file.
-		return
+	if not isFirstTimeDBSetup then
+		ucl.users = loadUsersFromDB()
+		if ucl.users then
+			-- We've loaded the users, so we don't need to do anything with the legacy file.
+			return
+		end
 	end
+	isFirstTimeDBSetup = false
 
 	-- Try to read from the safest locations first
 	local noMount = true

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -784,7 +784,7 @@ function ucl.addUser( id, allows, denies, group, from_CAMI )
 	if denies == ULib.DEFAULT_GRANT_ACCESS.deny then denies = table.Copy( denies ) end -- Otherwise we'd be changing all guest access
 	if group and not ucl.groups[ group ] then return error( "Group does not exist for adding user to (" .. group .. ")", 2 ) end
 
-	-- Lower case'ify
+	-- This doesn't do anything?
 	for k, v in ipairs( allows ) do allows[ k ] = v end
 	for k, v in ipairs( denies ) do denies[ k ] = v end
 

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -113,8 +113,6 @@ function ucl.saveUsers()
 	for steamid, userInfo in pairs( ucl.users ) do
 		ucl.saveUser(steamid, userInfo)
 	end
-
-	ULib.fileWrite( ULib.UCL_USERS, ULib.makeKeyValues( ucl.users ) )
 end
 
 local isFirstTimeDBSetup = false

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -145,7 +145,7 @@ function ucl.saveUser(steamid, userInfo)
 		REPLACE INTO ulib_users
 			(steamid, name, usergroup, allow, deny)
 		VALUES
-			("%s", "%s", "%s", "%s", "%s");
+			('%s', '%s', '%s', '%s', '%s');
 	]], escape(steamid), escape(userInfo.name), escape(userInfo.group), escape(allow), escape(deny)))
 end
 

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -122,8 +122,8 @@ function ucl.generateUserDB()
 		sql.Query([[
 			CREATE TABLE IF NOT EXISTS ulib_users (
 				steamid TEXT NOT NULL PRIMARY KEY,
-				name TEXT,
-				group TEXT NOT NULL DEFAULT "user",
+				name TEXT NULL,
+				usergroup TEXT NOT NULL DEFAULT "user",
 				allow TEXT,
 				deny TEXT
 			);
@@ -143,7 +143,7 @@ function ucl.saveUser(steamid, userInfo)
 
 	sql.Query(string.format([[
 		REPLACE INTO ulib_users
-			(steamid, name, group, allow, deny)
+			(steamid, name, usergroup, allow, deny)
 		VALUES
 			("%s", "%s", "%s", "%s", "%s");
 	]], escape(steamid), escape(userInfo.name), escape(userInfo.group), escape(allow), escape(deny)))

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -153,6 +153,15 @@ function ucl.saveUser( steamid, userInfo )
 	]], escape( steamid ), escape( userInfo.name or "" ), escape( userInfo.group ), escape( allow ), escape( deny )))
 end
 
+function ucl.deleteUser( steamid )
+	sql.Query(string.format([[
+		DELETE FROM
+			ulib_users
+		WHERE
+			steamid = '%s'
+	]], escape( steamid )))
+end
+
 local function reloadGroups()
 	-- Try to read from the safest locations first
 	local noMount = true

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -290,7 +290,6 @@ local function reloadUsers()
 			return
 		end
 	end
-	isFirstTimeDBSetup = false
 
 	-- Try to read from the safest locations first
 	local noMount = true
@@ -372,6 +371,12 @@ local function reloadUsers()
 			Msg( "Error while reading users file was: " .. err .. "\n" )
 		end
 		Msg( "Original file was backed up to " .. ULib.backupFile( ULib.UCL_USERS ) .. "\n" )
+		ucl.saveUsers()
+	end
+
+	if isFirstTimeDBSetup then
+		isFirstTimeDBSetup = false
+		Msg( "Migrating users file to users database.\n" )
 		ucl.saveUsers()
 	end
 end

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -162,6 +162,10 @@ function ucl.deleteUser( steamid )
 	]], escape( steamid )))
 end
 
+function ucl.deleteUsers()
+	sql.Query([[DELETE FROM ulib_users;]])
+end
+
 local function reloadGroups()
 	-- Try to read from the safest locations first
 	local noMount = true

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -291,7 +291,7 @@ local function reloadUsers()
 		end
 	end
 
-	-- Try to read from the safest locations first
+	-- Next, read from the users file.
 	local noMount = true
 	local path = ULib.UCL_USERS
 	if not ULib.fileExists( path, noMount ) then

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -118,7 +118,7 @@ function ucl.saveUsers()
 end
 
 local isFirstTimeDBSetup = false
-function ucl.generateUserDB()
+local function generateUserDB()
 	if not sql.TableExists("ulib_users") then
 		sql.Query([[
 			CREATE TABLE IF NOT EXISTS ulib_users (
@@ -132,7 +132,7 @@ function ucl.generateUserDB()
 		isFirstTimeDBSetup = true
 	end
 end
-ucl.generateUserDB()
+generateUserDB()
 
 local function escape(str)
 	return sql.SQLStr(str, true)

--- a/lua/ulib/server/ucl.lua
+++ b/lua/ulib/server/ucl.lua
@@ -793,7 +793,7 @@ function ucl.addUser( id, allows, denies, group, from_CAMI )
 	if ucl.users[ id ] and ucl.users[ id ].group then oldgroup = ucl.users[ id ].group end
 	ucl.users[ id ] = { allow=allows, deny=denies, group=group, name=name }
 
-	ucl.saveUsers()
+	ucl.saveUser( id, ucl.users[ id ] )
 
 	local ply = ULib.getPlyByID( id )
 	if ply then


### PR DESCRIPTION
Possibly fixes #38.

This prevents an entire file being rewritten for singular changes, and instead hands it off to the sqlite engine to handle instead.
Includes utility functions for saving individual users, all users, and deleting of the same.

I've tried to handle errors where possible, and re-use existing structures (ie, the user checks).
I've also tried to remain in the same style, though I suspect I've missed some parts, since it's not my normal style.

There has been some testing carried out, on a srcds instance with myself and a bot, though I would suggest code review and further testing prior to merging.

json was chosen as the storage medium for allow/deny rights, as the old function was causing newline(?) issues when inserting. Otherwise, the structure has been left as-is. If required, this can be changed to be an access rights table, but I suspect that'd be overkill for this project.

The groups file has been left as-is, this only changes the user storage, as that was the focus for #38.