### PR TITLE
Team Picker Target Keyword

### DIFF
--- a/lua/ulib/shared/player.lua
+++ b/lua/ulib/shared/player.lua
@@ -223,7 +223,7 @@ function ULib.getUsers( target, enable_keywords, ply )
 
 							-- This can't be ipairs, as it's indexed by ID, starts at 0 and may not be sequential.
 							for teamId, teamData in pairs( teams ) do
-								if teamData.name == teamNameOrId then
+								if teamData.Name == teamNameOrId then
 									for _, ply in ipairs( team.GetPlayers( teamId )) do
 										table.insert( tmpTargets, ply )
 									end

--- a/lua/ulib/shared/player.lua
+++ b/lua/ulib/shared/player.lua
@@ -136,10 +136,14 @@ end
 	Parameters:
 
 		target - A string of what you'd like to target. Accepts a comma separated list.
-		enable_keywords - *(Optional, defaults to false)* If true, the keywords "*" for all players, "^" for self,
-			"@" for picker (person in front of you), "#<group>" for those inside a specific group,
-			"%<group>" for users inside a group (counting inheritance), and "$<id>" for users matching a
-			particular ID will be activated.
+		enable_keywords - *(Optional, defaults to false)* If true, various keywords will be enabled:
+			"*" for all players,
+			"^" for self,
+			"@" for picker (person in front of you),
+			"#<group>" for those inside a specific group,
+			"%<group>" for users inside a group (counting inheritance),
+			"$<id>" for users matching a particular ID, and
+			"@<team>" for users inside a given team
 			Any of these can be negated with "!" before it. IE, "!^" targets everyone but yourself.
 		ply - *(Optional)* Player needing getUsers, this is necessary for some of the keywords.
 
@@ -152,6 +156,7 @@ end
 		v2.40 - Rewrite, added more keywords, removed immunity.
 		v2.50 - Added "#" and '$' keywords, removed special exception for "%user" (replaced by "#user").
 		v2.60 - Returns false if target is an empty string.
+		vx.xx - Added "@<team>" keyword extension.
 ]]
 function ULib.getUsers( target, enable_keywords, ply )
 	if target == "" then

--- a/lua/ulib/shared/player.lua
+++ b/lua/ulib/shared/player.lua
@@ -202,11 +202,35 @@ function ULib.getUsers( target, enable_keywords, ply )
 							return false, "You cannot target yourself from console!"
 						end
 					end
-				elseif piece == "@" then
-					if IsValid( ply ) then
-						local player = ULib.getPicker( ply )
-						if player then
-							table.insert( tmpTargets, player )
+				elseif piece:sub( 1, 1 ) == "@" then
+					if #peice == 1 then
+						if IsValid( ply ) then
+							local player = ULib.getPicker( ply )
+							if player then
+								table.insert( tmpTargets, player )
+							end
+						end
+					else
+						local teamNameOrId = peice:sub( 2 )
+						local teamId = tonumber( teamNameOrId )
+
+						if teamId then
+							for _, ply in ipairs( team.GetPlayers( teamId ) ) do
+								table.insert( tmpTargets, ply )
+							end
+						else
+							local teams = team.GetAllTeams()
+
+							-- This can't be ipairs, as it's indexed by ID, starts at 0 and may not be sequential.
+							for teamId, teamData in pairs( teams ) do
+								if teamData.name == teamNameOrId then
+									for _, ply in ipairs( team.GetPlayers( teamId )) do
+										table.insert( tmpTargets, ply )
+									end
+
+									break
+								end
+							end
 						end
 					end
 				elseif piece:sub( 1, 1 ) == "#" and ULib.ucl.groups[ piece:sub( 2 ) ] then

--- a/lua/ulib/shared/player.lua
+++ b/lua/ulib/shared/player.lua
@@ -224,7 +224,7 @@ function ULib.getUsers( target, enable_keywords, ply )
 							-- This can't be ipairs, as it's indexed by ID, starts at 0 and may not be sequential.
 							for teamId, teamData in pairs( teams ) do
 								if teamData.Name == teamNameOrId then
-									for _, ply in ipairs( team.GetPlayers( teamId )) do
+									for _, ply in ipairs( team.GetPlayers( teamId ) ) do
 										table.insert( tmpTargets, ply )
 									end
 

--- a/lua/ulib/shared/player.lua
+++ b/lua/ulib/shared/player.lua
@@ -203,7 +203,7 @@ function ULib.getUsers( target, enable_keywords, ply )
 						end
 					end
 				elseif piece:sub( 1, 1 ) == "@" then
-					if #peice == 1 then
+					if #piece == 1 then
 						if IsValid( ply ) then
 							local player = ULib.getPicker( ply )
 							if player then
@@ -211,7 +211,7 @@ function ULib.getUsers( target, enable_keywords, ply )
 							end
 						end
 					else
-						local teamNameOrId = peice:sub( 2 )
+						local teamNameOrId = piece:sub( 2 )
 						local teamId = tonumber( teamNameOrId )
 
 						if teamId then

--- a/lua/ulib/shared/player.lua
+++ b/lua/ulib/shared/player.lua
@@ -156,7 +156,7 @@ end
 		v2.40 - Rewrite, added more keywords, removed immunity.
 		v2.50 - Added "#" and '$' keywords, removed special exception for "%user" (replaced by "#user").
 		v2.60 - Returns false if target is an empty string.
-		vx.xx - Added "@<team>" keyword extension.
+		v2.70 - Added "@<team>" keyword extension.
 ]]
 function ULib.getUsers( target, enable_keywords, ply )
 	if target == "" then


### PR DESCRIPTION
Extends the "@" keyword to apply to teams.
@ without arguments remains as picker.
@<teamNameOrId> gets all users within a team.

This PR has been locally tested in a SRCDS instance with 1, 2 and 3 players, using the Citizen team on DarkRP.
1 player testing: 1 player in team, 0 players in team.
2 player testing: 2 / 0, players in / out, 1 / 1
3 player testing: 3 / 0, 2 / 1, 0 / 3

Fixes #9.