### PR TITLE
Fix Weapon SetClipErrors

### DIFF
--- a/lua/ulib/server/player.lua
+++ b/lua/ulib/server/player.lua
@@ -208,8 +208,6 @@ end
 		Updates player object to store health and armor. Has no effect unless ULib.Spawn is used later.
 ]]
 function ULib.getSpawnInfo( player )
-	local result = {}
-
 	local t = {}
 	player.ULibSpawnInfo = t
 	t.health = player:Health()

--- a/lua/ulib/server/player.lua
+++ b/lua/ulib/server/player.lua
@@ -219,15 +219,15 @@ function ULib.getSpawnInfo( ply )
 		t.curweapon = wep:GetClass()
 	end
 
-	local weapons = ply:GetWeapons()
 	local data = {}
+	local weapons = ply:GetWeapons()
 	for _, weapon in ipairs( weapons ) do
-		printname = weapon:GetClass()
-		data[ printname ] = {}
-		data[ printname ].clip1 = weapon:Clip1()
-		data[ printname ].clip2 = weapon:Clip2()
-		data[ printname ].ammo1 = ply:GetAmmoCount( weapon:GetPrimaryAmmoType() )
-		data[ printname ].ammo2 = ply:GetAmmoCount( weapon:GetSecondaryAmmoType() )
+		local class = weapon:GetClass()
+		data[ class ] = {}
+		data[ class ].clip1 = weapon:Clip1()
+		data[ class ].clip2 = weapon:Clip2()
+		data[ class ].ammo1 = ply:GetAmmoCount( weapon:GetPrimaryAmmoType() )
+		data[ class ].ammo2 = ply:GetAmmoCount( weapon:GetSecondaryAmmoType() )
 	end
 	t.data = data
 end

--- a/lua/ulib/server/player.lua
+++ b/lua/ulib/server/player.lua
@@ -239,13 +239,18 @@ local function doWeapons( player, t )
 	player:StripAmmo()
 	player:StripWeapons()
 
-	for printname, data in pairs( t.data ) do
-		player:Give( printname )
-		local weapon = player:GetWeapon( printname )
-		weapon:SetClip1( data.clip1 )
-		weapon:SetClip2( data.clip2 )
-		player:SetAmmo( data.ammo1, weapon:GetPrimaryAmmoType() )
-		player:SetAmmo( data.ammo2, weapon:GetSecondaryAmmoType() )
+	for class, data in pairs( t.data ) do
+		local weapon = player:Give( class )
+		if not IsValid( weapon ) then
+			weapon = player:GetWeapon( class )
+		end
+
+		if IsValid( weapon ) then
+			weapon:SetClip1( data.clip1 )
+			weapon:SetClip2( data.clip2 )
+			player:SetAmmo( data.ammo1, weapon:GetPrimaryAmmoType() )
+			player:SetAmmo( data.ammo2, weapon:GetSecondaryAmmoType() )
+		end
 	end
 
 	if t.curweapon then

--- a/lua/ulib/server/player.lua
+++ b/lua/ulib/server/player.lua
@@ -246,8 +246,14 @@ local function doWeapons( player, t )
 		end
 
 		if IsValid( weapon ) then
-			weapon:SetClip1( data.clip1 )
-			weapon:SetClip2( data.clip2 )
+			if weapon.SetClip1 then
+				weapon:SetClip1( data.clip1 )
+			end
+
+			if weapon.SetClip2 then
+				weapon:SetClip2( data.clip2 )
+			end
+
 			player:SetAmmo( data.ammo1, weapon:GetPrimaryAmmoType() )
 			player:SetAmmo( data.ammo2, weapon:GetSecondaryAmmoType() )
 		end

--- a/lua/ulib/server/player.lua
+++ b/lua/ulib/server/player.lua
@@ -207,24 +207,24 @@ end
 
 		Updates player object to store health and armor. Has no effect unless ULib.Spawn is used later.
 ]]
-function ULib.getSpawnInfo( player )
+function ULib.getSpawnInfo( ply )
 	local t = {}
-	player.ULibSpawnInfo = t
-	t.health = player:Health()
-	t.armor = player:Armor()
-	if player:GetActiveWeapon():IsValid() then
-		t.curweapon = player:GetActiveWeapon():GetClass()
+	ply.ULibSpawnInfo = t
+	t.health = ply:Health()
+	t.armor = ply:Armor()
+	if ply:GetActiveWeapon():IsValid() then
+		t.curweapon = ply:GetActiveWeapon():GetClass()
 	end
 
-	local weapons = player:GetWeapons()
+	local weapons = ply:GetWeapons()
 	local data = {}
 	for _, weapon in ipairs( weapons ) do
 		printname = weapon:GetClass()
 		data[ printname ] = {}
 		data[ printname ].clip1 = weapon:Clip1()
 		data[ printname ].clip2 = weapon:Clip2()
-		data[ printname ].ammo1 = player:GetAmmoCount( weapon:GetPrimaryAmmoType() )
-		data[ printname ].ammo2 = player:GetAmmoCount( weapon:GetSecondaryAmmoType() )
+		data[ printname ].ammo1 = ply:GetAmmoCount( weapon:GetPrimaryAmmoType() )
+		data[ printname ].ammo2 = ply:GetAmmoCount( weapon:GetSecondaryAmmoType() )
 	end
 	t.data = data
 end

--- a/lua/ulib/server/player.lua
+++ b/lua/ulib/server/player.lua
@@ -210,10 +210,13 @@ end
 function ULib.getSpawnInfo( ply )
 	local t = {}
 	ply.ULibSpawnInfo = t
+
 	t.health = ply:Health()
 	t.armor = ply:Armor()
-	if ply:GetActiveWeapon():IsValid() then
-		t.curweapon = ply:GetActiveWeapon():GetClass()
+
+	local wep = ply:GetActiveWeapon()
+	if IsValid( wep ) then
+		t.curweapon = wep:GetClass()
 	end
 
 	local weapons = ply:GetWeapons()


### PR DESCRIPTION
Realistically, there should never be a point at which SetClipX shouldn't be defined, so this PR can probably be closed without merger, however, this PR:
- Replaces printname with class, because it's a class not a printname.
- Performs some minor cleanup and optimisations.
- Fixes code to match documentation.
- Localises some unlocalised variables, which were only used in a local context.
- Make sure SetClipX functions are only called if they exist on the weapon (Fixes #48)