### PR TITLE
Fix old Addons not using strings

### DIFF
--- a/lua/ulib/server/util.lua
+++ b/lua/ulib/server/util.lua
@@ -113,6 +113,7 @@ local repCvarServerChanged
 function ULib.replicatedWritableCvar( sv_cvar, cl_cvar, default_value, save, notify, access )
 	sv_cvar = sv_cvar:lower()
 	cl_cvar = cl_cvar:lower()
+	default_value = tostring(default_value)
 
 	local flags = 0
 	if save then


### PR DESCRIPTION
Fixing #81, probably also #79

I know this is not a real fix, but due to many old addons using normal values instead of strings for this, I guess its better to make sure its a string.
Apparently the old umsg.String supported non-strings to be sent.

I tested it before this rework here and that still works:
https://github.com/TeamUlysses/ulib/commit/09c4e751a1deaec6202c7c5c23a8b11205720956#diff-dbb40aa172e92e98991fa2750b461bafed33dcc0bbe765cc2b40b32f159daa5cL196-R133