### PR TITLE
Allow use of strings in ULib.addBan as admin

### DIFF
--- a/lua/ulib/server/bans.lua
+++ b/lua/ulib/server/bans.lua
@@ -154,7 +154,7 @@ function ULib.addBan( steamid, time, reason, name, admin )
 			admin_name = "(Console)"
 		elseif admin:IsPlayer() then
 			admin_name = string.format("%s(%s)", admin:Name(), admin:SteamID())
-        elseif isstring(admin) then
+		elseif isstring(admin) then
 			admin_name = admin
 		end
 	end

--- a/lua/ulib/server/bans.lua
+++ b/lua/ulib/server/bans.lua
@@ -149,12 +149,15 @@ function ULib.addBan( steamid, time, reason, name, admin )
 	if reason == "" then reason = nil end
 
 	local admin_name
-	if admin then
-		admin_name = "(Console)"
-		if admin:IsValid() then
-			admin_name = string.format( "%s(%s)", admin:Name(), admin:SteamID() )
-		end
-	end
+    if admin then
+        if not IsValid(admin) then
+            admin_name = "(Console)"
+        elseif admin:IsPlayer() then
+            admin_name = string.format("%s(%s)", admin:Name(), admin:SteamID())
+        elseif isstring(admin) then
+            admin_name = admin
+        end
+    end
 
 	-- Clean up passed data
 	local t = {}

--- a/lua/ulib/server/bans.lua
+++ b/lua/ulib/server/bans.lua
@@ -149,15 +149,15 @@ function ULib.addBan( steamid, time, reason, name, admin )
 	if reason == "" then reason = nil end
 
 	local admin_name
-    if admin then
-        if not IsValid(admin) then
-            admin_name = "(Console)"
-        elseif admin:IsPlayer() then
-            admin_name = string.format("%s(%s)", admin:Name(), admin:SteamID())
+	if admin then
+		if not IsValid(admin) then
+			admin_name = "(Console)"
+		elseif admin:IsPlayer() then
+			admin_name = string.format("%s(%s)", admin:Name(), admin:SteamID())
         elseif isstring(admin) then
-            admin_name = admin
-        end
-    end
+			admin_name = admin
+		end
+	end
 
 	-- Clean up passed data
 	local t = {}


### PR DESCRIPTION
Currently only players can be passed to the `admin` arg, it'd be great to allow the use of strings here for automated tools.
