### PR TITLE
Simplify the purpose of PostCommandCalled

### DIFF
--- a/lua/ulib/server/concommand.lua
+++ b/lua/ulib/server/concommand.lua
@@ -25,7 +25,6 @@ ULib.sayCmds = ULib.sayCmds or {}
 	Revisions:
 
 		v2.10 - Made case-insensitive
-		v2.72 - Added ULibPostCommandCalled
 ]]
 local function sayCmdCheck( ply, strText, bTeam )
 	local match
@@ -69,8 +68,7 @@ local function sayCmdCheck( ply, strText, bTeam )
 		local fn = data.fn
 		local hide = data.hide
 
-		local err = ULib.pcallError( fn, ply, match:Trim(), argv, args )
-		hook.Call( ULib.HOOK_POST_COMMAND_CALLED, _, ply, data.__cmd, argv, hide, not err )
+		ULib.pcallError( fn, ply, match:Trim(), argv, args )
 
 		if hide then return "" end
 	end

--- a/lua/ulib/shared/commands.lua
+++ b/lua/ulib/shared/commands.lua
@@ -948,8 +948,8 @@ local function translateCmdCallback( ply, commandName, argv )
 		end
 	end
 
-	cmd:call( isOpposite, unpack( args ) )
-	hook.Call( ULib.HOOK_POST_TRANSLATED_COMMAND, _, ply, commandName, args )
+	local callResult = cmd:call( isOpposite, unpack( args ) )
+	hook.Call( ULib.HOOK_POST_TRANSLATED_COMMAND, _, ply, commandName, args, callResult )
 end
 
 local function translateAutocompleteCallback( commandName, args )
@@ -1315,7 +1315,6 @@ end
 	Revisions:
 
 		v2.62 - Initial
-		v2.72 - Added ULibPostCommandCalled
 ]]
 function cmds.execute( cmdTable, ply, commandName, argv )
 	if CLIENT and not cmdTable.__client_only then
@@ -1330,7 +1329,6 @@ function cmds.execute( cmdTable, ply, commandName, argv )
 	local return_value = hook.Call( ULib.HOOK_COMMAND_CALLED, _, ply, commandName, argv )
 	if return_value ~= false then
 		cmdTable.__fn( ply, commandName, argv )
-		hook.Call( ULib.HOOK_POST_COMMAND_CALLED, _, ply, commandName, argv )
 	end
 end
 

--- a/lua/ulib/shared/defines.lua
+++ b/lua/ulib/shared/defines.lua
@@ -117,25 +117,6 @@ ULib.HOOK_LOCALPLAYERREADY = "ULibLocalPlayerReady"
 ULib.HOOK_COMMAND_CALLED = "ULibCommandCalled"
 
 --[[
-	Hook: ULibPostCommandCalled
-
-	Called *on server* after a ULib command is run.
-
-	Parameters passed to callback:
-
-		ply - The player that executed the command.
-		commandName - The command that was executed.
-		args - The table of args for the command.
-		hide - If triggered from a chat command, a boolean indicating if the output of the command should be hidden.
-		success - If triggered from a chat command, a boolean indicating if the command ran successfully.
-
-	Revisions:
-
-		v2.72 - Initial
-]]
-ULib.HOOK_POST_COMMAND_CALLED = "ULibPostCommandCalled"
-
---[[
 	Hook: ULibPlayerTarget
 
 	Called whenever one player is about to target another player. Called *BEFORE* any other validation
@@ -186,10 +167,12 @@ ULib.HOOK_PLAYER_TARGETS = "ULibPlayerTargets" -- Exactly the same as the above 
 		ply - The player that executed the command.
 		commandName - The command that's being executed.
 		translated_args - A table of the translated arguments, as passed into the callback function itself.
+		callResult - The return value of the command function.
 
 	Revisions:
 
 		v2.40 - Initial
+		v2.72 - Add the callResult parameter
 ]]
 ULib.HOOK_POST_TRANSLATED_COMMAND = "ULibPostTranslatedCommand"
 


### PR DESCRIPTION
### Context
In my [original PR](https://github.com/TeamUlysses/ulib/pull/80), I implemented a whole new hook (`ULibPostCommandCalled`) that was supposed to only be called if a command successfully ran.

My original PR was bad - it simply didn't work correctly.
This PR aims to rectify that mistake with a simpler and more targeted approach.


### Description
 - ❌ Removes the `ULibPostCommandCalled` hook
 - ✅ Adds a fourth parameter to the `ULibPostCommandTranslated` hook (the `callResult` of the command function)

This PR adds a fourth parameter to the `ULibPostCommandTranslated` hook. This parameter is just the result of calling the base command function.

This will allow command functions to, for example, `return false` if they failed for some reason. This was my primary focus - I wanted to know if a ULX command actually successfully performed the action. However, this also opens to door to any kind of pre -> post command interaction.

Maybe some developers would like to return a table with additional information about what happened in the command.

It's a very flexible change, and the more creative uses of this change probably exceed the limits of my imagination at present :)


### More Info
I've also created a [Draft PR to the ULX project](https://github.com/TeamUlysses/ulx/pull/205) that demonstrates how this could be used.

With that ULX change, developers could check for the fourth parameter to `ULibPostTranslatedCommand` hook to see if the function actually ran successfully. This is the bare-minimum functionality this PR could provide.
