### PR TITLE
Use game.KickID instead of RunConsoleCommand

### DIFF
--- a/lua/ulib/server/bans.lua
+++ b/lua/ulib/server/bans.lua
@@ -198,7 +198,7 @@ function ULib.addBan( steamid, time, reason, name, admin )
 	end
 
 	-- This redundant kick is to ensure they're kicked -- even if they're joining
-	RunConsoleCommand("kickid", steamid, shortReason or "")
+	game.KickID( steamid, shortReason or "" )
 
 	writeBan( t )
 	hook.Call( ULib.HOOK_USER_BANNED, _, steamid, t )


### PR DESCRIPTION
For some reason, `RunConsoleCommand` `kickid` doesn't seem to properly kick players when they're being banned as they're connecting. After testing i've found that `game.KickID` does work.

Thanks for MrPresident to suggest this function