### PR TITLE
Fix leaked global

### DIFF
--- a/lua/ulib/shared/commands.lua
+++ b/lua/ulib/shared/commands.lua
@@ -1352,9 +1352,8 @@ local function routedCommandCallback( ply, commandName, argv )
 	if not routedCmds[ commandName:lower() ] then
 		return error( "Base command \"" .. commandName .. "\" is not defined!" )
 	end
-	local orig_argv = argv
-	local orig_commandName = commandName
 
+	local currTable
 	currTable, commandName, argv = cmds.getCommandTableAndArgv( commandName, argv, true )
 	cmds.execute( currTable, ply, commandName, argv )
 end


### PR DESCRIPTION
Simple fix. Previously, `currTable` was a global on both Server and Client.

This fixes it with no apparent impact on running commands 👍